### PR TITLE
Add cargo-deny CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
           command: test
           args: --no-default-features --features=lz4
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@v0
+
   publish_check:
     name: Publish check
     runs-on: ubuntu-latest
@@ -104,21 +110,21 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: [test, publish_check]
+    needs: [test, cargo-deny, publish_check]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: cargo publish
-      uses: actions-rs/cargo@v1
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      with:
-        command: publish
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo publish
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        with:
+          command: publish

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+[bans]
+multiple-versions = "deny"
+deny = [
+]
+skip = [
+    # lz4 with skeptic brings in old dependency, skip for now
+    { name = "glob", version = "=0.2" },
+    # lz4 and skeptic brings in old rand, skip for now
+    { name = "rand_core", version = "=0.3" },
+]
+
+[licenses]
+unlicensed = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.92
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Zlib",
+]


### PR DESCRIPTION
To prevent duplicate transitive dependencies and only allow permissive licenses for dependencies.

This uses the new GitHub Action for cargo-deny:
https://github.com/EmbarkStudios/cargo-deny-action