### PR TITLE
Disable default features on all dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Explicitly enable only the features needed on the dependency crates
+
 ## 0.1.4 (2019-02-07)
 
 * Fix build issue with tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ codegen-units = 1
 elapsed = "0.1.2"
 
 [dependencies]
-bincode = { version = "1.2.0", optional = true }
-brotli = { version = "3.3.0", optional = true }
-bs58 = { version = "0.3.0", optional = true }
-flate2 = { version = "1.0.13", optional = true }
-xz2 = { version = "0.1.6", optional = true }
-lz4 = { version = "1.23.1", optional = true }
-zstd = { version="0.5.1+zstd.1.4.4", default-features = false, optional = true }
+bincode = { version = "1.2.0",            optional = true, default-features = false }
+brotli  = { version = "3.3.0",            optional = true, default-features = false, features = ["std"] }
+bs58    = { version = "0.3.0",            optional = true, default-features = false, features = ["std"] }
+flate2  = { version = "1.0.13",           optional = true, default-features = false, features = ["rust_backend"] }
+xz2     = { version = "0.1.6",            optional = true, default-features = false }
+lz4     = { version = "1.23.1",           optional = true, default-features = false }
+zstd    = { version = "0.5.1+zstd.1.4.4", optional = true, default-features = false }
 
 [features]
 default = ["all"]


### PR DESCRIPTION
This didn't seem to have an affect in practice but at least will prevent new features or dependencies from creeping in newer versions of the dependencies