### PR TITLE
Remove elapsed dev-dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Remove `elapsed` dependency used by example
+
 ## 0.1.4 (2019-02-07)
 
 * Fix build issue with tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ lto = true
 opt-level = 3
 codegen-units = 1
 
-[dev-dependencies]
-elapsed = "0.1.2"
-
 [dependencies]
 bincode = { version = "1.2.0", optional = true }
 brotli = { version = "3.3.0", optional = true }


### PR DESCRIPTION
It has not been updated in 3 years, has only 3k downloads, and is only used in the example.

So replaced it with just a bit more verbose explicit std timing code